### PR TITLE
add custom save-as filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ automatically.
 ```sh
 $ yoinks https://youtu.be/dQw4w9WgXcQ    # straight to the format picker
 $ yoinks                                 # prompts for a url
+$ yoinks <url> --sa "my clip"             # save as my clip.mp4 (or .mp3)
 $ yoinks --theme light                   # force the light palette
 ```
 
@@ -43,6 +44,9 @@ hit enter. `esc` goes back, `^c` quits. Or just use the mouse — the yoink
 button, the format list and the footer hints are all clickable, and
 clicking the logo takes you back home. Files are saved to `~/Downloads`,
 and the file path is printed to your terminal when you're done.
+Use `--sa <name>` to override the content-derived filename; yoinks keeps the
+extension that matches the format you pick. In the format picker, press `s`
+to enter or edit the same optional save-as name in the TUI.
 
 The default `auto` theme uses your terminal's own foreground and background,
 so it follows light and dark terminal themes without guessing. Press `^t` or

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -15,6 +15,7 @@ import {clickTargetAt, findFrameRow, frameRowSpan, type ClickTarget} from './lib
 import {formatBytes, formatDuration, formatEta, formatSpeed, shortenPath, truncate, wrapText} from './lib/format.js'
 import {addToHistory, loadHistory} from './lib/history.js'
 import {detectPlatform, isProbablyUrl, type Platform} from './lib/platforms.js'
+import {validateSaveAs} from './lib/save-as.js'
 import {useMouseClick} from './lib/use-mouse-click.js'
 import {nextThemeMode, ThemeProvider, type ThemeMode, useTheme} from './theme.js'
 import {
@@ -111,6 +112,7 @@ const HINTS: Record<Phase['name'], Array<[string, string]>> = {
   picking: [
     ['↑↓', 'choose'],
     ['↵', 'yoink'],
+    ['s', 'save as'],
     ['esc', 'back'],
     ['^c', 'quit'],
   ],
@@ -129,6 +131,7 @@ type AppProps = {
   initialUrl?: string
   clipboardUrl?: string
   initialThemeMode?: ThemeMode
+  initialSaveAs?: string
   onOutcome: (outcome: Outcome) => void
 }
 
@@ -148,11 +151,13 @@ export function App({initialThemeMode = 'auto', ...props}: AppProps) {
 function AppContent({
   initialUrl,
   clipboardUrl,
+  initialSaveAs,
   onOutcome,
   cycleTheme,
 }: {
   initialUrl?: string
   clipboardUrl?: string
+  initialSaveAs?: string
   onOutcome: (outcome: Outcome) => void
   cycleTheme: () => void
 }) {
@@ -161,6 +166,9 @@ function AppContent({
   const {stdout} = useStdout()
   const [url, setUrl] = useState(initialUrl ?? '')
   const [urlInput, setUrlInput] = useState('')
+  const [saveAs, setSaveAs] = useState(initialSaveAs ?? '')
+  const [saveAsError, setSaveAsError] = useState<string>()
+  const [editingSaveAs, setEditingSaveAs] = useState(false)
   const [history, setHistory] = useState(loadHistory)
   const [platform, setPlatform] = useState<Platform>()
   const [info, setInfo] = useState<VideoInfo>()
@@ -210,6 +218,9 @@ function AppContent({
     setPlatform(undefined)
     setInfo(undefined)
     setChoices([])
+    setSaveAs('')
+    setSaveAsError(undefined)
+    setEditingSaveAs(false)
     setPhase({name: 'input'})
   }, [])
 
@@ -223,6 +234,14 @@ function AppContent({
     (input, key) => {
       if (key.ctrl && input === 't') {
         cycleTheme()
+        return
+      }
+      if (phase.name === 'picking' && editingSaveAs && key.escape) {
+        setEditingSaveAs(false)
+        return
+      }
+      if (phase.name === 'picking' && !editingSaveAs && input === 's') {
+        setEditingSaveAs(true)
         return
       }
       if (key.escape && (phase.name === 'picking' || phase.name === 'error' || phase.name === 'done')) resetToInput()
@@ -247,6 +266,13 @@ function AppContent({
 
   const handlePick = (item: {value: number}) => {
     const choice = choices[item.value]
+    const finalName = saveAs.trim()
+    const nameError = finalName ? validateSaveAs(finalName) : undefined
+    if (nameError) {
+      setSaveAsError(nameError)
+      setEditingSaveAs(true)
+      return
+    }
     const controller = new AbortController()
     abortRef.current = controller
     setPhase({name: 'downloading', choice, processing: false})
@@ -259,7 +285,14 @@ function AppContent({
       }
       try {
         const ffmpegLocation = await findFfmpeg()
-        const base = {ytdlp: ytdlpRef.current, ffmpegLocation, url, choice, outDir: OUT_DIR}
+        const base = {
+          ytdlp: ytdlpRef.current,
+          ffmpegLocation,
+          url,
+          choice,
+          outDir: OUT_DIR,
+          saveAs: finalName || undefined,
+        }
         let filepath: string
         try {
           // reuse the probe's metadata — starts immediately instead of re-extracting
@@ -283,6 +316,14 @@ function AppContent({
   }
 
   let hints: Array<[string, string]> = [...HINTS[phase.name], ['^t', `theme:${theme.mode}`]]
+  if (phase.name === 'picking' && editingSaveAs) {
+    hints = [
+      ['↵', 'finish name'],
+      ['esc', 'cancel edit'],
+      ['^c', 'quit'],
+      ['^t', `theme:${theme.mode}`],
+    ]
+  }
   if (phase.name === 'input' && history.length > 0) {
     hints = [hints[0]!, ['↑', 'history'], ...hints.slice(1)]
   }
@@ -293,9 +334,12 @@ function AppContent({
   const hintAction = (key: string): (() => void) | undefined => {
     if (key === '^c') return () => exit()
     if (key === '^t') return cycleTheme
+    if (key === 's' && phase.name === 'picking') return () => setEditingSaveAs(true)
+    if (key === 'esc' && phase.name === 'picking' && editingSaveAs) return () => setEditingSaveAs(false)
     if (key === 'esc') return phase.name === 'probing' || phase.name === 'downloading' ? cancelRun : resetToInput
     if (key === '↵') {
       if (phase.name === 'input') return () => handleUrlSubmit(urlInput)
+      if (phase.name === 'picking' && editingSaveAs) return () => setEditingSaveAs(false)
       if (phase.name === 'picking') return () => handlePick({value: highlightRef.current})
       if (phase.name === 'error' || phase.name === 'done') return resetToInput
     }
@@ -310,6 +354,7 @@ function AppContent({
     for (const [index, choice] of choices.entries()) {
       clickTargets.push({match: choiceLabel(choice), action: () => handlePick({value: index})})
     }
+    clickTargets.push({match: 'save as', action: () => setEditingSaveAs(true)})
   }
   if (phase.name === 'done') {
     clickTargets.push({match: DONE_LABEL, padX: 4, padY: 1, action: resetToInput})
@@ -406,7 +451,26 @@ function AppContent({
               }))}
               onSelect={handlePick}
               onHighlight={item => (highlightRef.current = item.value)}
+              isFocused={!editingSaveAs}
             />
+            <Gap />
+            <Text color={theme.gray} dimColor={theme.dimSecondary}>save as (optional)</Text>
+            <TextInput
+              value={saveAs}
+              onChange={value => {
+                setSaveAs(value)
+                setSaveAsError(undefined)
+              }}
+              onSubmit={() => setEditingSaveAs(false)}
+              placeholder="content title"
+              width={30}
+              isActive={editingSaveAs}
+            />
+            {saveAsError ? (
+              <Text color={theme.gray} dimColor={theme.dimSecondary}>✗ {saveAsError}</Text>
+            ) : (
+              <Text color={theme.gray} dimColor={theme.dimSecondary}>extension added automatically</Text>
+            )}
           </Panel>
         </Box>
       )}

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -15,14 +15,16 @@ const HELP = `
   yoinks — yoink any video. paste. yoink. done.
 
   Usage
-    $ yoinks [url]
+    $ yoinks [url] [--sa <name>]
 
   Examples
     $ yoinks https://youtu.be/dQw4w9WgXcQ
     $ yoinks https://x.com/user/status/123456
+    $ yoinks https://youtu.be/dQw4w9WgXcQ --sa "my clip"
     $ yoinks                 (prompts for a url)
 
   Options
+    --sa <name>      save with this name (extension is added automatically)
     --theme <mode>  use auto, light, or dark for this run
     -h, --help      show this help
     -v, --version   show version
@@ -50,6 +52,7 @@ if (args.version) {
 
 const initialUrl = args.initialUrl
 const initialThemeMode = args.themeMode ?? 'auto'
+const initialSaveAs = args.saveAs
 
 const isTTY = Boolean(process.stdout.isTTY)
 
@@ -85,6 +88,7 @@ const {waitUntilExit} = render(
     initialUrl={initialUrl}
     clipboardUrl={clipboardUrl}
     initialThemeMode={initialThemeMode}
+    initialSaveAs={initialSaveAs}
     onOutcome={result => (outcome = result)}
   />,
   // keep a copy of every frame so clicks can be hit-tested against it

--- a/src/components/text-input.tsx
+++ b/src/components/text-input.tsx
@@ -16,6 +16,8 @@ type Props = {
   submitOnPaste?: (value: string) => boolean
   /** tab pressed — accept a suggestion, etc. */
   onTab?: () => void
+  /** whether this editor should receive keyboard input */
+  isActive?: boolean
 }
 
 const wordLeft = (text: string, from: number) => {
@@ -47,6 +49,7 @@ export function TextInput({
   history = [],
   submitOnPaste,
   onTab,
+  isActive = true,
 }: Props) {
   const theme = useTheme()
   const [cursorState, setCursorState] = useState(value.length)
@@ -166,7 +169,7 @@ export function TextInput({
     edit(next, start + clean.length)
     // a multi-char chunk is a paste — submit right away when it completes the field
     if (clean.length > 1 && value === '' && submitOnPaste?.(next.trim())) onSubmit?.(next)
-  })
+  }, {isActive})
 
   // scroll the window so the cursor stays visible (it can sit one past the end)
   const span = Math.max(8, width)

--- a/src/lib/args.test.ts
+++ b/src/lib/args.test.ts
@@ -21,11 +21,24 @@ test('parses an equals-style theme option after the url', () => {
   })
 })
 
+test('parses spaced and equals-style save-as options', () => {
+  assert.deepEqual(parseArgs(['--sa', 'my video', 'https://example.com/video']), {
+    help: false,
+    version: false,
+    saveAs: 'my video',
+    initialUrl: 'https://example.com/video',
+  })
+  assert.equal(parseArgs(['https://example.com/video', '--sa=clip.mp4']).saveAs, 'clip.mp4')
+})
+
 test('rejects missing, invalid, and unknown options', () => {
   assert.match(parseArgs(['--theme']).error ?? '', /needs a value/)
   assert.match(parseArgs(['--theme', 'sepia']).error ?? '', /unknown theme/)
   assert.match(parseArgs(['--wat']).error ?? '', /unknown option/)
   assert.match(parseArgs(['one', 'two']).error ?? '', /single url/)
+  assert.match(parseArgs(['--sa']).error ?? '', /needs a filename/)
+  assert.match(parseArgs(['--sa', '--theme', 'light']).error ?? '', /needs a filename/)
+  assert.match(parseArgs(['--sa=../clip']).error ?? '', /cannot contain/)
 })
 
 test('recognizes only supported modes and cycles through all of them', () => {

--- a/src/lib/args.ts
+++ b/src/lib/args.ts
@@ -1,10 +1,12 @@
 import {isThemeMode, type ThemeMode} from '../theme.js'
+import {validateSaveAs} from './save-as.js'
 
 export type CliArgs = {
   help: boolean
   version: boolean
   initialUrl?: string
   themeMode?: ThemeMode
+  saveAs?: string
   error?: string
 }
 
@@ -27,6 +29,17 @@ export function parseArgs(args: string[]): CliArgs {
       const value = arg.slice('--theme='.length)
       if (!isThemeMode(value)) return {...result, error: `unknown theme “${value}” — use auto, light, or dark`}
       result.themeMode = value
+    } else if (arg === '--sa') {
+      const value = args[++index]
+      if (!value || value.startsWith('--')) return {...result, error: '--sa needs a filename'}
+      const error = validateSaveAs(value)
+      if (error) return {...result, error}
+      result.saveAs = value.trim()
+    } else if (arg.startsWith('--sa=')) {
+      const value = arg.slice('--sa='.length)
+      const error = validateSaveAs(value)
+      if (error) return {...result, error}
+      result.saveAs = value.trim()
     } else if (arg.startsWith('-')) {
       return {...result, error: `unknown option “${arg}”`}
     } else {

--- a/src/lib/save-as.test.ts
+++ b/src/lib/save-as.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+import test from 'node:test'
+import {saveAsOutputTemplate, validateSaveAs} from './save-as.js'
+
+test('uses the original title template when no save-as name is supplied', () => {
+  assert.equal(saveAsOutputTemplate('/downloads', undefined), path.join('/downloads', '%(title).60s.%(ext)s'))
+})
+
+test('uses the requested name while keeping the selected format extension', () => {
+  assert.equal(saveAsOutputTemplate('/downloads', 'my clip'), path.join('/downloads', 'my clip.%(ext)s'))
+  assert.equal(saveAsOutputTemplate('/downloads', 'song.mp3'), path.join('/downloads', 'song.%(ext)s'))
+  assert.equal(saveAsOutputTemplate('/downloads', 'clip.mp4'), path.join('/downloads', 'clip.%(ext)s'))
+})
+
+test('escapes yt-dlp template characters and rejects paths', () => {
+  assert.equal(saveAsOutputTemplate('/downloads', '100% mine'), path.join('/downloads', '100%% mine.%(ext)s'))
+  assert.match(validateSaveAs('../clip') ?? '', /cannot contain/)
+  assert.match(validateSaveAs('clip/name') ?? '', /cannot contain/)
+  assert.match(validateSaveAs('CON') ?? '', /reserved/)
+})

--- a/src/lib/save-as.ts
+++ b/src/lib/save-as.ts
@@ -1,0 +1,32 @@
+import path from 'node:path'
+
+const INVALID_FILENAME_CHARS = /[<>:"/\\|?*\x00-\x1f]/
+const WINDOWS_RESERVED_NAME = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i
+
+/** Return a user-facing error when a save-as value is not a plain filename. */
+export function validateSaveAs(value: string): string | undefined {
+  const name = value.trim()
+  if (!name) return 'save-as name cannot be empty'
+  if (name === '.' || name === '..') return 'save-as name must be a filename'
+  if (INVALID_FILENAME_CHARS.test(name)) return 'save-as name cannot contain < > : " / \\ | ? *'
+  if (/[. ]$/.test(name)) return 'save-as name cannot end with a dot or space'
+  if (WINDOWS_RESERVED_NAME.test(name)) return `“${name}” is a reserved filename`
+  return undefined
+}
+
+/** Build a safe yt-dlp output template, retaining the selected format's extension. */
+export function saveAsOutputTemplate(
+  outDir: string,
+  saveAs: string | undefined,
+): string {
+  if (!saveAs) return path.join(outDir, '%(title).60s.%(ext)s')
+
+  const error = validateSaveAs(saveAs)
+  if (error) throw new Error(error)
+
+  const trimmed = saveAs.trim()
+  const stem = /\.(mp3|mp4)$/i.test(trimmed) ? trimmed.slice(0, -4) : trimmed
+
+  // A literal percent must be doubled inside a yt-dlp output template.
+  return path.join(outDir, `${stem.replaceAll('%', '%%')}.%(ext)s`)
+}

--- a/src/lib/ytdlp.ts
+++ b/src/lib/ytdlp.ts
@@ -6,6 +6,7 @@ import path from 'node:path'
 import {Readable} from 'node:stream'
 import {pipeline} from 'node:stream/promises'
 import {formatBytes} from './format.js'
+import {saveAsOutputTemplate} from './save-as.js'
 
 const YOINKS_DIR = path.join(os.homedir(), '.yoinks', 'bin')
 const RELEASE_BASE = 'https://github.com/yt-dlp/yt-dlp/releases/latest/download'
@@ -224,6 +225,7 @@ export function download(
     infoJsonPath?: string
     choice: DownloadChoice
     outDir: string
+    saveAs?: string
   },
   handlers: DownloadHandlers,
   signal?: AbortSignal,
@@ -244,7 +246,7 @@ export function download(
     'after_move:filepath',
     '--no-simulate',
     '-o',
-    path.join(opts.outDir, '%(title).60s.%(ext)s'),
+    saveAsOutputTemplate(opts.outDir, opts.saveAs),
   ]
   if (opts.ffmpegLocation) args.push('--ffmpeg-location', opts.ffmpegLocation)
 


### PR DESCRIPTION
## What changed

- add `--sa <name>` to override the content-derived filename
- add an optional save-as editor to the format picker with the `s` shortcut
- validate filenames, escape yt-dlp template characters, and retain the selected output extension
- document the CLI and TUI flows and cover argument/output-template behavior with tests

## Why

Downloads always used the hardcoded `%(title).60s.%(ext)s` output template, so users could not choose a final filename. The new save-as value is passed through the CLI/TUI into a safe yt-dlp output template while the original title-based behavior remains the default.

Closes #6.

## Checks

- `npm test`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
