### PR TITLE
feat: add --cookies-from-browser flag for login-walled sites

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -129,6 +129,7 @@ type AppProps = {
   initialUrl?: string
   clipboardUrl?: string
   initialThemeMode?: ThemeMode
+  cookiesFromBrowser?: string
   onOutcome: (outcome: Outcome) => void
 }
 
@@ -148,11 +149,13 @@ export function App({initialThemeMode = 'auto', ...props}: AppProps) {
 function AppContent({
   initialUrl,
   clipboardUrl,
+  cookiesFromBrowser,
   onOutcome,
   cycleTheme,
 }: {
   initialUrl?: string
   clipboardUrl?: string
+  cookiesFromBrowser?: string
   onOutcome: (outcome: Outcome) => void
   cycleTheme: () => void
 }) {
@@ -187,7 +190,7 @@ function AppContent({
       ytdlpRef.current = ytdlp
       if (controller.signal.aborted) return
       setPhase({name: 'probing', status: 'fetching video info…'})
-      const {info: videoInfo, infoJsonPath} = await probe(ytdlp, targetUrl, controller.signal)
+      const {info: videoInfo, infoJsonPath} = await probe(ytdlp, targetUrl, controller.signal, cookiesFromBrowser)
       if (controller.signal.aborted) return
       infoJsonRef.current = infoJsonPath
       setInfo(videoInfo)
@@ -259,7 +262,7 @@ function AppContent({
       }
       try {
         const ffmpegLocation = await findFfmpeg()
-        const base = {ytdlp: ytdlpRef.current, ffmpegLocation, url, choice, outDir: OUT_DIR}
+        const base = {ytdlp: ytdlpRef.current, ffmpegLocation, url, choice, outDir: OUT_DIR, cookiesFromBrowser}
         let filepath: string
         try {
           // reuse the probe's metadata — starts immediately instead of re-extracting

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -24,6 +24,7 @@ const HELP = `
 
   Options
     --theme <mode>  use auto, light, or dark for this run
+    --cookies-from-browser <browser>  use cookies from an installed browser (chrome, firefox, safari, edge, brave, …)
     -h, --help      show this help
     -v, --version   show version
 
@@ -85,6 +86,7 @@ const {waitUntilExit} = render(
     initialUrl={initialUrl}
     clipboardUrl={clipboardUrl}
     initialThemeMode={initialThemeMode}
+    cookiesFromBrowser={args.cookiesFromBrowser}
     onOutcome={result => (outcome = result)}
   />,
   // keep a copy of every frame so clicks can be hit-tested against it

--- a/src/lib/args.test.ts
+++ b/src/lib/args.test.ts
@@ -21,9 +21,29 @@ test('parses an equals-style theme option after the url', () => {
   })
 })
 
+test('parses a spaced cookies-from-browser option without confusing the value for the url', () => {
+  assert.deepEqual(parseArgs(['--cookies-from-browser', 'firefox', 'https://example.com/video']), {
+    help: false,
+    version: false,
+    cookiesFromBrowser: 'firefox',
+    initialUrl: 'https://example.com/video',
+  })
+})
+
+test('parses an equals-style cookies-from-browser option after the url', () => {
+  assert.deepEqual(parseArgs(['https://example.com/video', '--cookies-from-browser=chrome']), {
+    help: false,
+    version: false,
+    cookiesFromBrowser: 'chrome',
+    initialUrl: 'https://example.com/video',
+  })
+})
+
 test('rejects missing, invalid, and unknown options', () => {
   assert.match(parseArgs(['--theme']).error ?? '', /needs a value/)
   assert.match(parseArgs(['--theme', 'sepia']).error ?? '', /unknown theme/)
+  assert.match(parseArgs(['--cookies-from-browser']).error ?? '', /needs a value/)
+  assert.match(parseArgs(['--cookies-from-browser=']).error ?? '', /needs a value/)
   assert.match(parseArgs(['--wat']).error ?? '', /unknown option/)
   assert.match(parseArgs(['one', 'two']).error ?? '', /single url/)
 })

--- a/src/lib/args.ts
+++ b/src/lib/args.ts
@@ -5,6 +5,7 @@ export type CliArgs = {
   version: boolean
   initialUrl?: string
   themeMode?: ThemeMode
+  cookiesFromBrowser?: string
   error?: string
 }
 
@@ -27,6 +28,14 @@ export function parseArgs(args: string[]): CliArgs {
       const value = arg.slice('--theme='.length)
       if (!isThemeMode(value)) return {...result, error: `unknown theme “${value}” — use auto, light, or dark`}
       result.themeMode = value
+    } else if (arg === '--cookies-from-browser') {
+      const value = args[++index]
+      if (!value) return {...result, error: '--cookies-from-browser needs a value: chrome, firefox, safari, edge, brave, …'}
+      result.cookiesFromBrowser = value
+    } else if (arg.startsWith('--cookies-from-browser=')) {
+      const value = arg.slice('--cookies-from-browser='.length)
+      if (!value) return {...result, error: '--cookies-from-browser needs a value: chrome, firefox, safari, edge, brave, …'}
+      result.cookiesFromBrowser = value
     } else if (arg.startsWith('-')) {
       return {...result, error: `unknown option “${arg}”`}
     } else {

--- a/src/lib/ytdlp.ts
+++ b/src/lib/ytdlp.ts
@@ -103,9 +103,17 @@ export type ProbeResult = {
   infoJsonPath: string
 }
 
-export async function probe(ytdlp: string, url: string, signal?: AbortSignal): Promise<ProbeResult> {
+export async function probe(
+  ytdlp: string,
+  url: string,
+  signal?: AbortSignal,
+  cookiesFromBrowser?: string,
+): Promise<ProbeResult> {
+  const args = ['-J', '--no-playlist', '--no-warnings']
+  if (cookiesFromBrowser) args.push('--cookies-from-browser', cookiesFromBrowser)
+  args.push(url)
   const stdout = await new Promise<string>((resolve, reject) => {
-    const child = spawn(ytdlp, ['-J', '--no-playlist', '--no-warnings', url], {signal})
+    const child = spawn(ytdlp, args, {signal})
     let out = ''
     let stderr = ''
     child.stdout.on('data', chunk => (out += chunk))
@@ -224,12 +232,14 @@ export function download(
     infoJsonPath?: string
     choice: DownloadChoice
     outDir: string
+    cookiesFromBrowser?: string
   },
   handlers: DownloadHandlers,
   signal?: AbortSignal,
 ): Promise<string> {
   const args = [
     ...(opts.infoJsonPath ? ['--load-info-json', opts.infoJsonPath] : [opts.url]),
+    ...(opts.cookiesFromBrowser ? ['--cookies-from-browser', opts.cookiesFromBrowser] : []),
     ...opts.choice.args,
     '--no-playlist',
     '--no-warnings',


### PR DESCRIPTION
Adds a `--cookies-from-browser <browser>` flag so yoinks can grab login-walled content (X, Instagram, TikTok, etc). The flag is passed through to yt-dlp on both the probe and download steps, since the probe also needs cookies for restricted pages.

Resolves #11.