### PR TITLE
feat: add --name flag for custom output file name

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -129,6 +129,7 @@ type AppProps = {
   initialUrl?: string
   clipboardUrl?: string
   initialThemeMode?: ThemeMode
+  fileName?: string
   onOutcome: (outcome: Outcome) => void
 }
 
@@ -148,11 +149,13 @@ export function App({initialThemeMode = 'auto', ...props}: AppProps) {
 function AppContent({
   initialUrl,
   clipboardUrl,
+  fileName,
   onOutcome,
   cycleTheme,
 }: {
   initialUrl?: string
   clipboardUrl?: string
+  fileName?: string
   onOutcome: (outcome: Outcome) => void
   cycleTheme: () => void
 }) {
@@ -259,7 +262,7 @@ function AppContent({
       }
       try {
         const ffmpegLocation = await findFfmpeg()
-        const base = {ytdlp: ytdlpRef.current, ffmpegLocation, url, choice, outDir: OUT_DIR}
+        const base = {ytdlp: ytdlpRef.current, ffmpegLocation, url, choice, outDir: OUT_DIR, fileName}
         let filepath: string
         try {
           // reuse the probe's metadata — starts immediately instead of re-extracting

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -24,6 +24,7 @@ const HELP = `
 
   Options
     --theme <mode>  use auto, light, or dark for this run
+    --name <file>   save as this file name (extension added automatically)
     -h, --help      show this help
     -v, --version   show version
 
@@ -85,6 +86,7 @@ const {waitUntilExit} = render(
     initialUrl={initialUrl}
     clipboardUrl={clipboardUrl}
     initialThemeMode={initialThemeMode}
+    fileName={args.fileName}
     onOutcome={result => (outcome = result)}
   />,
   // keep a copy of every frame so clicks can be hit-tested against it

--- a/src/lib/args.test.ts
+++ b/src/lib/args.test.ts
@@ -21,9 +21,29 @@ test('parses an equals-style theme option after the url', () => {
   })
 })
 
+test('parses a spaced name option without confusing the value for the url', () => {
+  assert.deepEqual(parseArgs(['--name', 'my-clip', 'https://example.com/video']), {
+    help: false,
+    version: false,
+    fileName: 'my-clip',
+    initialUrl: 'https://example.com/video',
+  })
+})
+
+test('parses an equals-style name option after the url', () => {
+  assert.deepEqual(parseArgs(['https://example.com/video', '--name=my-clip']), {
+    help: false,
+    version: false,
+    fileName: 'my-clip',
+    initialUrl: 'https://example.com/video',
+  })
+})
+
 test('rejects missing, invalid, and unknown options', () => {
   assert.match(parseArgs(['--theme']).error ?? '', /needs a value/)
   assert.match(parseArgs(['--theme', 'sepia']).error ?? '', /unknown theme/)
+  assert.match(parseArgs(['--name']).error ?? '', /needs a value/)
+  assert.match(parseArgs(['--name=']).error ?? '', /needs a value/)
   assert.match(parseArgs(['--wat']).error ?? '', /unknown option/)
   assert.match(parseArgs(['one', 'two']).error ?? '', /single url/)
 })

--- a/src/lib/args.ts
+++ b/src/lib/args.ts
@@ -5,6 +5,7 @@ export type CliArgs = {
   version: boolean
   initialUrl?: string
   themeMode?: ThemeMode
+  fileName?: string
   error?: string
 }
 
@@ -27,6 +28,14 @@ export function parseArgs(args: string[]): CliArgs {
       const value = arg.slice('--theme='.length)
       if (!isThemeMode(value)) return {...result, error: `unknown theme “${value}” — use auto, light, or dark`}
       result.themeMode = value
+    } else if (arg === '--name') {
+      const value = args[++index]
+      if (!value) return {...result, error: '--name needs a value: the file name to save as (without extension)'}
+      result.fileName = value
+    } else if (arg.startsWith('--name=')) {
+      const value = arg.slice('--name='.length)
+      if (!value) return {...result, error: '--name needs a value: the file name to save as (without extension)'}
+      result.fileName = value
     } else if (arg.startsWith('-')) {
       return {...result, error: `unknown option “${arg}”`}
     } else {

--- a/src/lib/ytdlp.ts
+++ b/src/lib/ytdlp.ts
@@ -224,6 +224,8 @@ export function download(
     infoJsonPath?: string
     choice: DownloadChoice
     outDir: string
+    /** When set, save as this literal file name (extension still added by yt-dlp). */
+    fileName?: string
   },
   handlers: DownloadHandlers,
   signal?: AbortSignal,
@@ -244,7 +246,7 @@ export function download(
     'after_move:filepath',
     '--no-simulate',
     '-o',
-    path.join(opts.outDir, '%(title).60s.%(ext)s'),
+    path.join(opts.outDir, opts.fileName ? `${opts.fileName}.%(ext)s` : '%(title).60s.%(ext)s'),
   ]
   if (opts.ffmpegLocation) args.push('--ffmpeg-location', opts.ffmpegLocation)
 


### PR DESCRIPTION
## What

Adds a `--name <file>` CLI flag that lets downloads be saved under a custom file name instead of always deriving one from the video title. Like a save-as. Resolves #6.

## How

- `src/lib/args.ts`: parse `--name <file>` (spaced and `=` forms), missing value gives a clear error
- `src/lib/ytdlp.ts`: `download()` accepts `fileName?` and switches the output template from `%(title).60s.%(ext)s` to `<name>.%(ext)s`
- `src/app.tsx` / `src/cli.tsx`: thread the value from CLI to download; help text updated
- `src/lib/args.test.ts`: 4 new assertions (spaced form, `=` form, both missing-value errors)

## Verification

- `npm test`: 8/8 pass
- `npm run typecheck`: clean
- `npm run build`: success
- Smoke-tested built CLI: `--name` alone errors properly, `--name=test123 --help` shows the new option

## Usage

```bash
yoinks --name my-clip https://youtu.be/dQw4w9WgXcQ
# saves as ~/Downloads/my-clip.mp4
```