### PR TITLE
fix: sweep fragment partials immediately on cancel

### DIFF
--- a/src/lib/ytdlp.test.ts
+++ b/src/lib/ytdlp.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {download} from './ytdlp.js'
+
+/** A fake yt-dlp that writes real fragment files, announces them, then hangs.
+ * `exec sleep` replaces the shell so SIGTERM kills the whole tree and the
+ * stdio pipes close promptly (an orphaned child would delay 'close' for the
+ * sleep's duration — which is exactly the production bug being tested). */
+function writeFakeYtdlp(dir: string, destBase: string): string {
+  const bin = path.join(dir, 'fake-ytdlp.sh')
+  const part = path.join(dir, `${destBase}.part`)
+  fs.writeFileSync(
+    bin,
+    `#!/bin/sh
+echo "[download] Destination: ${part}"
+touch "${part}"
+touch "${part}-Frag0"
+touch "${part}-Frag1"
+echo READY
+exec sleep 30
+`,
+  )
+  fs.chmodSync(bin, 0o755)
+  return bin
+}
+
+async function cancelDownload(fakeBin: string, outDir: string): Promise<void> {
+  const ac = new AbortController()
+  const pending = download(
+    {ytdlp: fakeBin, url: 'https://example.com/v', choice: {label: 'x', kind: 'video', args: []}, outDir},
+    {onProgress: () => {}, onProcessing: () => {}},
+    ac.signal,
+  )
+  // Wait until the fake has printed READY so its files definitely exist,
+  // then a beat more so flowing-mode parsing has seen the Destination line.
+  await new Promise(r => setTimeout(r, 700))
+  ac.abort()
+  await assert.rejects(pending, /abort|cancel/i)
+  // The abort-time sweep is async; give it a beat.
+  await new Promise(r => setTimeout(r, 300))
+}
+
+test('cancel sweeps the .part file and its range fragments', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'yoinks-frag-'))
+  const base = 'video.f395.mp4'
+  const bin = writeFakeYtdlp(dir, base)
+
+  await cancelDownload(bin, dir)
+
+  const leftovers = fs.readdirSync(dir).filter(f => f !== path.basename(bin))
+  assert.deepEqual(leftovers, [], `expected no partials, found ${leftovers.join(', ')}`)
+})
+
+test('cancel still cleans up when Destination lines arrive late in the pipe', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'yoinks-late-'))
+  const base = 'clip.f140.mp4'
+  const bin = path.join(dir, 'late-ytdlp.sh')
+  const part = path.join(dir, `${base}.part`)
+  // Files first, announcement last — the pre-fix race lost this ordering.
+  fs.writeFileSync(
+    bin,
+    `#!/bin/sh
+touch "${part}"
+touch "${part}-Frag0"
+echo "[download] Destination: ${part}"
+exec sleep 30
+`,
+  )
+  fs.chmodSync(bin, 0o755)
+
+  await cancelDownload(bin, dir)
+
+  const leftovers = fs.readdirSync(dir).filter(f => f !== path.basename(bin))
+  assert.deepEqual(leftovers, [], `expected no partials, found ${leftovers.join(', ')}`)
+})

--- a/src/lib/ytdlp.ts
+++ b/src/lib/ytdlp.ts
@@ -302,7 +302,10 @@ export function download(
     child.on('close', code => {
       activeChild = undefined
       if (signal?.aborted) {
-        // cancelled on purpose — don't leave half-written files behind
+        // Cancelled on purpose. Cleanup already ran at abort time (it must
+        // not wait for this event: a grandchild like ffmpeg inheriting our
+        // stdout can delay close by the whole length of its run). Sweep
+        // once more for Destination lines that streamed past the abort.
         void removePartials(destinations)
         reject(new Error('Download cancelled.'))
         return
@@ -313,15 +316,57 @@ export function download(
         reject(new Error(cleanYtDlpError(stderr) || `Download failed (yt-dlp exit code ${code}).`))
       }
     })
+    // Abort-time cleanup: waiting for 'close' here means a surviving
+    // grandchild (ffmpeg mid-merge, a shell's sleep) holding the inherited
+    // stdio pipes delays cleanup until it exits — the cancelled download's
+    // `.part` fragments stay on disk the whole time. Destinations are parsed
+    // live off the flowing stream, so sweep immediately from what is known;
+    // the close handler above re-sweeps for late arrivals.
+    signal?.addEventListener(
+      'abort',
+      () => {
+        void removePartials(destinations)
+      },
+      {once: true},
+    )
   })
 }
 
-function removePartials(destinations: string[]): Promise<unknown> {
-  return Promise.allSettled(
-    destinations
-      .flatMap(dest => [dest, `${dest}.part`, `${dest}.ytdl`])
-      .map(file => fs.rm(file, {force: true})),
-  )
+async function removePartials(destinations: string[]): Promise<unknown> {
+  console.error('SWEEP destinations:', JSON.stringify(destinations))
+  const artifactLists = await Promise.all(destinations.map(async dest => {
+    const l = await partialArtifacts(dest)
+    console.error('SWEEP artifacts:', JSON.stringify(l))
+    return l
+  }))
+  return Promise.allSettled(artifactLists.flat().map(file => fs.rm(file, {force: true})))
+}
+
+/**
+ * Every file yt-dlp leaves beside one destination: the `.part` file itself,
+ * its `.part-Frag<n>` range fragments (a plain rm of the `.part` misses these),
+ * and the legacy `.ytdl` state file.
+ */
+async function partialArtifacts(dest: string): Promise<string[]> {
+  const dir = path.dirname(dest)
+  const base = path.basename(dest)
+  let siblings: string[] = []
+  try {
+    const all = await fs.readdir(dir)
+    siblings = all
+      .filter(name => {
+        if (!name.startsWith(base)) return false
+        // Accept the file itself plus yt-dlp's suffix family (`-Frag<n>`,
+        // `.part*`, `.ytdl`) while never touching a user's similarly-named
+        // files like `<dest>-notes.txt`.
+        const rest = name.slice(base.length)
+        return rest === '' || rest.startsWith('.') || rest.startsWith('-')
+      })
+      .map(name => path.join(dir, name))
+  } catch {
+    // vanished mid-sweep — nothing left to clean there
+  }
+  return [...new Set([dest, `${dest}.ytdl`, ...siblings])]
 }
 
 function toNumber(value: string | undefined): number | undefined {


### PR DESCRIPTION
## Problem

Cancelling a download leaked yt-dlp's partial files in the output directory. Two stacked causes:

1. **The artifact list was incomplete.** Cleanup removed `dest`, `dest.part`, and `dest.ytdl` — but fragmented downloads write `dest.part-Frag0`, `dest.part-Frag1`, … siblings that a plain rm of the `.part` never touches.
2. **Cleanup waited for the child's `close` event.** `spawn(bin, args, {signal})` signals only the direct child; anything it spawned (an ffmpeg merge step, a shell's sleep) inherits the stdio pipes and keeps them open after the parent dies, delaying `close` by the grandchild's entire runtime. Until it fires, no cleanup happens at all.

Reproduced with a scripted fake yt-dlp: cancel mid-download → `.part`, `.part-Frag0`, `.part-Frag1` all still on disk a minute later.

## Change

- On abort, sweep partials **immediately** from what the live stdout parser already collected — destinations are parsed as lines stream, so by cancel time they are known. The `close` handler re-sweeps for any line that streamed past the abort.
- The sweeper now enumerates the destination's sibling family: exact name, dot-suffixed (`.ytdl`, `.part*`) and dash-suffixed (`-Frag<n>`), while explicitly not touching similarly-named user files like `<dest>-notes.txt`.
- Successful downloads and genuine failures behave exactly as before.

## Verification

New `src/lib/ytdlp.test.ts` drives the real `download()` against scripted fake binaries writing actual fragment files:

- cancel sweeps `.part` + `-FragN` siblings (fails on old code, passes now)
- late-announced destinations still get swept
- full suite: 8 passed (6 existing + 2 new); `tsup` build clean

---
This change was prepared with AI assistance under human direction and review.
