### PR TITLE
Qol/faster downloads and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,16 @@ age-gated, and — more and more often — ordinary Instagram posts. So yoinks
 signs in as you by default: it finds an installed browser (Firefox first,
 since Chromium browsers encrypt their cookie store on macOS and Windows)
 and lets yt-dlp borrow its cookies. The footer names the browser in use.
-If those cookies turn out to be unreadable — locked profile, encrypted
-store — it quietly carries on signed out rather than failing the download.
+If borrowed cookies turn out to be unusable — locked profile, encrypted
+store, a site that rejects them — it quietly carries on signed out rather
+than failing the download.
+
+YouTube is the one exception: automatic sign-in skips it. YouTube rotates
+the cookies of a signed-in session constantly, so a running browser's jar
+is usually stale by the time yt-dlp reads it, and the player answers
+“The page needs to be reloaded” for a video that downloads fine signed
+out. Pinning a browser with `--cookies firefox` still covers YouTube —
+that one is a deliberate choice, and age-gated videos need it.
 
 Use `--cookies firefox` (or `chrome`, `brave`, `edge`, `safari`, …) to pin
 a specific browser, `--cookies none` to stay signed out, and

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ automatically.
 $ yoinks https://youtu.be/dQw4w9WgXcQ    # straight to the format picker
 $ yoinks                                 # prompts for a url
 $ yoinks --theme light                   # force the light palette
+$ yoinks --update                        # refresh the bundled yt-dlp now
 ```
 
 yoinks takes over the terminal (full-screen, centered — and restores your
@@ -42,7 +43,9 @@ scrollback on exit). Pick a format with ↑/↓ (or j/k, or number keys) and
 hit enter. `esc` goes back, `^c` quits. Or just use the mouse — the yoink
 button, the format list and the footer hints are all clickable, and
 clicking the logo takes you back home. Files are saved to `~/Downloads`,
-and the file path is printed to your terminal when you're done.
+and the file path is printed to your terminal when you're done. On the
+finished screen, `o` opens the download in your file manager (Finder and
+Explorer highlight the file itself).
 
 The default `auto` theme uses your terminal's own foreground and background,
 so it follows light and dark terminal themes without guessing. Press `^t` or
@@ -57,6 +60,12 @@ click the theme control in the footer to cycle through `auto`, `light`, and
 - Powered by [yt-dlp](https://github.com/yt-dlp/yt-dlp). On first run,
   yoinks downloads the standalone yt-dlp binary to `~/.yoinks/bin` —
   no Python required. If you already have yt-dlp installed, it uses yours.
+- That downloaded copy refreshes itself in the background roughly once a
+  week, because sites break old yt-dlp builds faster than anyone updates
+  them by hand. `yoinks --update` does it on demand. A yt-dlp you installed
+  yourself is never overwritten — update it however you installed it.
+- Fragmented streams (YouTube, HLS) are fetched four fragments at a time,
+  which gets around per-connection throttling.
 - ffmpeg (needed for merging high-res streams and mp3 extraction) is found
   on your PATH, with `ffmpeg-static` as a bundled fallback.
 - The UI is [Ink](https://github.com/vadimdemedes/ink) — React for the
@@ -81,7 +90,7 @@ To try it as a global command without publishing: `npm link`, then run
 - [ ] `-o <dir>` to choose the output folder
 - [ ] Playlist / thread-with-multiple-videos support
 - [ ] Clipboard detection: launch bare and auto-suggest the url you copied
-- [ ] Self-update for the bundled yt-dlp binary (`yt-dlp -U`)
+- [x] Self-update for the bundled yt-dlp binary
 - [x] Publish to npm (`npm i -g yoinks` / `npx yoinks`)
 - [ ] `curl yoinks.sh | sh` installer
 

--- a/README.md
+++ b/README.md
@@ -36,17 +36,21 @@ $ yoinks https://youtu.be/dQw4w9WgXcQ    # straight to the format picker
 $ yoinks                                 # prompts for a url
 $ yoinks --theme light                   # force the light palette
 $ yoinks --update                        # refresh the bundled yt-dlp now
-$ yoinks --cookies firefox                # sign in with your browser's cookies
+$ yoinks --cookies none                  # download signed out
 ```
 
 Some links need you to be logged in: private accounts, stories, anything
-age-gated, and — more and more often — ordinary Instagram posts. Point
-yoinks at a browser you're signed into with `--cookies firefox` (or
-`chrome`, `brave`, `edge`, `safari`, …) and yt-dlp borrows that browser's
-cookies. The choice is remembered, so it's a one-time setup; the footer
-shows which browser is in use, and `--cookies none` forgets it. Chrome on
-macOS and Windows encrypts its cookie store, so Firefox is the more
-reliable pick there.
+age-gated, and — more and more often — ordinary Instagram posts. So yoinks
+signs in as you by default: it finds an installed browser (Firefox first,
+since Chromium browsers encrypt their cookie store on macOS and Windows)
+and lets yt-dlp borrow its cookies. The footer names the browser in use.
+If those cookies turn out to be unreadable — locked profile, encrypted
+store — it quietly carries on signed out rather than failing the download.
+
+Use `--cookies firefox` (or `chrome`, `brave`, `edge`, `safari`, …) to pin
+a specific browser, `--cookies none` to stay signed out, and
+`--cookies auto` to go back to picking automatically. Whatever you choose
+is remembered in `~/.config/yoinks/config.json`.
 
 yoinks takes over the terminal (full-screen, centered — and restores your
 scrollback on exit). Pick a format with ↑/↓ (or j/k, or number keys) and

--- a/README.md
+++ b/README.md
@@ -36,7 +36,17 @@ $ yoinks https://youtu.be/dQw4w9WgXcQ    # straight to the format picker
 $ yoinks                                 # prompts for a url
 $ yoinks --theme light                   # force the light palette
 $ yoinks --update                        # refresh the bundled yt-dlp now
+$ yoinks --cookies firefox                # sign in with your browser's cookies
 ```
+
+Some links need you to be logged in: private accounts, stories, anything
+age-gated, and — more and more often — ordinary Instagram posts. Point
+yoinks at a browser you're signed into with `--cookies firefox` (or
+`chrome`, `brave`, `edge`, `safari`, …) and yt-dlp borrows that browser's
+cookies. The choice is remembered, so it's a one-time setup; the footer
+shows which browser is in use, and `--cookies none` forgets it. Chrome on
+macOS and Windows encrypts its cookie store, so Firefox is the more
+reliable pick there.
 
 yoinks takes over the terminal (full-screen, centered — and restores your
 scrollback on exit). Pick a format with ↑/↓ (or j/k, or number keys) and

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -14,6 +14,7 @@ import {TextInput} from './components/text-input.js'
 import {clickTargetAt, findFrameRow, frameRowSpan, type ClickTarget} from './lib/click-map.js'
 import {formatBytes, formatDuration, formatEta, formatSpeed, shortenPath, truncate, wrapText} from './lib/format.js'
 import {addToHistory, loadHistory} from './lib/history.js'
+import {cookiesForUrl} from './lib/browsers.js'
 import {detectPlatform, isProbablyUrl, type Platform} from './lib/platforms.js'
 import {revealInFileManager} from './lib/reveal.js'
 import {useMouseClick} from './lib/use-mouse-click.js'
@@ -184,6 +185,9 @@ function AppContent({
   const ytdlpRef = useRef('')
   // cookies for this session: dropped for good once they prove unusable
   const cookiesRef = useRef(cookiesFrom)
+  // …and the ones the current link actually went out with, so the download
+  // repeats exactly what the probe got away with
+  const usedCookiesRef = useRef<string | undefined>(undefined)
   const [activeCookies, setActiveCookies] = useState(cookiesFrom)
   const highlightRef = useRef(0) // choice under the cursor, for the ↵ hint click
   const infoJsonRef = useRef<string | undefined>(undefined)
@@ -206,15 +210,24 @@ function AppContent({
       ytdlpRef.current = ytdlp
       if (controller.signal.aborted) return
       setPhase({name: 'probing', status: 'fetching video info…'})
+      // cookies a browser we guessed may be locked, encrypted, or simply
+      // unwelcome on this site — never let them cost a link that works
+      // signed out anyway
+      const wanted = cookiesForUrl(cookiesRef.current, cookiesAuto, targetUrl)
+      usedCookiesRef.current = wanted
       let result
       try {
-        result = await probe(ytdlp, targetUrl, {cookiesFrom: cookiesRef.current}, controller.signal)
+        result = await probe(ytdlp, targetUrl, {cookiesFrom: wanted}, controller.signal)
       } catch (error) {
-        // a browser we picked ourselves may keep its cookies locked or
-        // encrypted — no reason to fail a link that works signed out anyway
-        if (!cookiesAuto || !cookiesRef.current || controller.signal.aborted || !isCookieProblem(error)) throw error
-        cookiesRef.current = undefined
-        setActiveCookies(undefined)
+        if (!cookiesAuto || !wanted || controller.signal.aborted) throw error
+        // an unreadable cookie store stays unreadable: stop asking for the
+        // rest of the session. Any other failure only retires the cookies
+        // for this one link
+        if (isCookieProblem(error)) {
+          cookiesRef.current = undefined
+          setActiveCookies(undefined)
+        }
+        usedCookiesRef.current = undefined
         result = await probe(ytdlp, targetUrl, {}, controller.signal)
       }
       const {info: videoInfo, infoJsonPath} = result
@@ -305,7 +318,7 @@ function AppContent({
           ffmpegLocation,
           url,
           choice,
-          cookiesFrom: cookiesRef.current,
+          cookiesFrom: usedCookiesRef.current,
           outDir: OUT_DIR,
         }
         let filepath: string

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -134,8 +134,15 @@ type AppProps = {
   clipboardUrl?: string
   initialThemeMode?: ThemeMode
   cookiesFrom?: string
+  /** True when the browser was guessed rather than chosen — see cli.tsx. */
+  cookiesAuto?: boolean
   onOutcome: (outcome: Outcome) => void
 }
+
+// yt-dlp says things like "could not find firefox cookies database in …" or
+// "failed to decrypt with DPAPI"; all of them name the cookies
+const isCookieProblem = (error: unknown) =>
+  /cookie/i.test(error instanceof Error ? error.message : String(error))
 
 export function App({initialThemeMode = 'auto', ...props}: AppProps) {
   const [themeMode, setThemeMode] = useState(initialThemeMode)
@@ -154,12 +161,14 @@ function AppContent({
   initialUrl,
   clipboardUrl,
   cookiesFrom,
+  cookiesAuto,
   onOutcome,
   cycleTheme,
 }: {
   initialUrl?: string
   clipboardUrl?: string
   cookiesFrom?: string
+  cookiesAuto?: boolean
   onOutcome: (outcome: Outcome) => void
   cycleTheme: () => void
 }) {
@@ -173,6 +182,9 @@ function AppContent({
   const [info, setInfo] = useState<VideoInfo>()
   const [choices, setChoices] = useState<DownloadChoice[]>([])
   const ytdlpRef = useRef('')
+  // cookies for this session: dropped for good once they prove unusable
+  const cookiesRef = useRef(cookiesFrom)
+  const [activeCookies, setActiveCookies] = useState(cookiesFrom)
   const highlightRef = useRef(0) // choice under the cursor, for the ↵ hint click
   const infoJsonRef = useRef<string | undefined>(undefined)
   const abortRef = useRef<AbortController | undefined>(undefined)
@@ -194,7 +206,18 @@ function AppContent({
       ytdlpRef.current = ytdlp
       if (controller.signal.aborted) return
       setPhase({name: 'probing', status: 'fetching video info…'})
-      const {info: videoInfo, infoJsonPath} = await probe(ytdlp, targetUrl, {cookiesFrom}, controller.signal)
+      let result
+      try {
+        result = await probe(ytdlp, targetUrl, {cookiesFrom: cookiesRef.current}, controller.signal)
+      } catch (error) {
+        // a browser we picked ourselves may keep its cookies locked or
+        // encrypted — no reason to fail a link that works signed out anyway
+        if (!cookiesAuto || !cookiesRef.current || controller.signal.aborted || !isCookieProblem(error)) throw error
+        cookiesRef.current = undefined
+        setActiveCookies(undefined)
+        result = await probe(ytdlp, targetUrl, {}, controller.signal)
+      }
+      const {info: videoInfo, infoJsonPath} = result
       if (controller.signal.aborted) return
       infoJsonRef.current = infoJsonPath
       setInfo(videoInfo)
@@ -205,7 +228,7 @@ function AppContent({
       if (controller.signal.aborted) return
       setPhase({name: 'error', message: error instanceof Error ? error.message : String(error)})
     }
-  }, [cookiesFrom])
+  }, [cookiesAuto])
 
   useEffect(() => {
     if (initialUrl) void startProbe(initialUrl)
@@ -277,7 +300,14 @@ function AppContent({
       }
       try {
         const ffmpegLocation = await findFfmpeg()
-        const base = {ytdlp: ytdlpRef.current, ffmpegLocation, url, choice, cookiesFrom, outDir: OUT_DIR}
+        const base = {
+          ytdlp: ytdlpRef.current,
+          ffmpegLocation,
+          url,
+          choice,
+          cookiesFrom: cookiesRef.current,
+          outDir: OUT_DIR,
+        }
         let filepath: string
         try {
           // reuse the probe's metadata — starts immediately instead of re-extracting
@@ -525,10 +555,10 @@ function AppContent({
                   </Text>
                   <Text color={theme.gray} dimColor={theme.dimSecondary}> {phase.status}</Text>
                 </Text>
-              ) : phase.name === 'input' && cookiesFrom ? (
+              ) : phase.name === 'input' && activeCookies ? (
                 // a remembered --cookies setting is silent otherwise, and
                 // "why is it logged in as me?" deserves an answer on screen
-                <Text color={theme.gray} dimColor={theme.dimSecondary}>cookies: {cookiesFrom}</Text>
+                <Text color={theme.gray} dimColor={theme.dimSecondary}>cookies: {activeCookies}</Text>
               ) : undefined
             }
           />

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -15,6 +15,7 @@ import {clickTargetAt, findFrameRow, frameRowSpan, type ClickTarget} from './lib
 import {formatBytes, formatDuration, formatEta, formatSpeed, shortenPath, truncate, wrapText} from './lib/format.js'
 import {addToHistory, loadHistory} from './lib/history.js'
 import {detectPlatform, isProbablyUrl, type Platform} from './lib/platforms.js'
+import {revealInFileManager} from './lib/reveal.js'
 import {useMouseClick} from './lib/use-mouse-click.js'
 import {nextThemeMode, ThemeProvider, type ThemeMode, useTheme} from './theme.js'
 import {
@@ -118,7 +119,10 @@ const HINTS: Record<Phase['name'], Array<[string, string]>> = {
     ['esc', 'cancel'],
     ['^c', 'quit'],
   ],
-  done: [['^c', 'quit']],
+  done: [
+    ['o', 'open folder'],
+    ['^c', 'quit'],
+  ],
   error: [
     ['↵', 'try again'],
     ['^c', 'quit'],
@@ -204,12 +208,19 @@ function AppContent({
     if (initialUrl) void startProbe(initialUrl)
   }, [initialUrl, startProbe])
 
+  const [revealFailed, setRevealFailed] = useState(false)
+
+  const openFolder = useCallback((filepath: string) => {
+    void revealInFileManager(filepath).then(opened => setRevealFailed(!opened))
+  }, [])
+
   const resetToInput = useCallback(() => {
     setUrl('')
     setUrlInput('')
     setPlatform(undefined)
     setInfo(undefined)
     setChoices([])
+    setRevealFailed(false)
     setPhase({name: 'input'})
   }, [])
 
@@ -223,6 +234,10 @@ function AppContent({
     (input, key) => {
       if (key.ctrl && input === 't') {
         cycleTheme()
+        return
+      }
+      if (input === 'o' && !key.ctrl && !key.meta && phase.name === 'done') {
+        openFolder(phase.filepath)
         return
       }
       if (key.escape && (phase.name === 'picking' || phase.name === 'error' || phase.name === 'done')) resetToInput()
@@ -293,6 +308,7 @@ function AppContent({
   const hintAction = (key: string): (() => void) | undefined => {
     if (key === '^c') return () => exit()
     if (key === '^t') return cycleTheme
+    if (key === 'o' && phase.name === 'done') return () => openFolder(phase.filepath)
     if (key === 'esc') return phase.name === 'probing' || phase.name === 'downloading' ? cancelRun : resetToInput
     if (key === '↵') {
       if (phase.name === 'input') return () => handleUrlSubmit(urlInput)
@@ -471,6 +487,9 @@ function AppContent({
             <Text color={theme.primary}>find your file in:</Text>
           </Text>
           <Text color={theme.gray} dimColor={theme.dimSecondary}>{shortenPath(phase.filepath, os.homedir(), 60)}</Text>
+          {revealFailed ? (
+            <Text color={theme.gray} dimColor={theme.dimSecondary}>✗ no file manager to open it with</Text>
+          ) : null}
           <Gap />
           <Box
             borderStyle="round"

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -133,6 +133,7 @@ type AppProps = {
   initialUrl?: string
   clipboardUrl?: string
   initialThemeMode?: ThemeMode
+  cookiesFrom?: string
   onOutcome: (outcome: Outcome) => void
 }
 
@@ -152,11 +153,13 @@ export function App({initialThemeMode = 'auto', ...props}: AppProps) {
 function AppContent({
   initialUrl,
   clipboardUrl,
+  cookiesFrom,
   onOutcome,
   cycleTheme,
 }: {
   initialUrl?: string
   clipboardUrl?: string
+  cookiesFrom?: string
   onOutcome: (outcome: Outcome) => void
   cycleTheme: () => void
 }) {
@@ -191,7 +194,7 @@ function AppContent({
       ytdlpRef.current = ytdlp
       if (controller.signal.aborted) return
       setPhase({name: 'probing', status: 'fetching video info…'})
-      const {info: videoInfo, infoJsonPath} = await probe(ytdlp, targetUrl, controller.signal)
+      const {info: videoInfo, infoJsonPath} = await probe(ytdlp, targetUrl, {cookiesFrom}, controller.signal)
       if (controller.signal.aborted) return
       infoJsonRef.current = infoJsonPath
       setInfo(videoInfo)
@@ -202,7 +205,7 @@ function AppContent({
       if (controller.signal.aborted) return
       setPhase({name: 'error', message: error instanceof Error ? error.message : String(error)})
     }
-  }, [])
+  }, [cookiesFrom])
 
   useEffect(() => {
     if (initialUrl) void startProbe(initialUrl)
@@ -274,7 +277,7 @@ function AppContent({
       }
       try {
         const ffmpegLocation = await findFfmpeg()
-        const base = {ytdlp: ytdlpRef.current, ffmpegLocation, url, choice, outDir: OUT_DIR}
+        const base = {ytdlp: ytdlpRef.current, ffmpegLocation, url, choice, cookiesFrom, outDir: OUT_DIR}
         let filepath: string
         try {
           // reuse the probe's metadata — starts immediately instead of re-extracting
@@ -522,6 +525,10 @@ function AppContent({
                   </Text>
                   <Text color={theme.gray} dimColor={theme.dimSecondary}> {phase.status}</Text>
                 </Text>
+              ) : phase.name === 'input' && cookiesFrom ? (
+                // a remembered --cookies setting is silent otherwise, and
+                // "why is it logged in as me?" deserves an answer on screen
+                <Text color={theme.gray} dimColor={theme.dimSecondary}>cookies: {cookiesFrom}</Text>
               ) : undefined
             }
           />

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -6,6 +6,7 @@ import {captureFrames} from './lib/click-map.js'
 import {parseArgs} from './lib/args.js'
 import {readClipboard} from './lib/clipboard.js'
 import {isProbablyUrl} from './lib/platforms.js'
+import {autoUpdateYtDlp, updateYtDlp} from './lib/ytdlp.js'
 
 // read at runtime from the shipped package.json so npm version bumps
 // can't drift from a hardcoded constant
@@ -24,10 +25,12 @@ const HELP = `
 
   Options
     --theme <mode>  use auto, light, or dark for this run
+    --update        update the bundled yt-dlp now, then exit
     -h, --help      show this help
     -v, --version   show version
 
   Downloads are saved to ~/Downloads.
+  yt-dlp refreshes itself in the background about once a week.
   Powered by yt-dlp — YouTube, X, Instagram, Threads, TikTok & 1800+ sites.
 `
 
@@ -45,6 +48,26 @@ if (args.help) {
 
 if (args.version) {
   console.log(VERSION)
+  process.exit(0)
+}
+
+// plain stdout on purpose — an update is a one-shot chore, not a session
+if (args.update) {
+  console.log('yoinks: checking yt-dlp…')
+  const result = await updateYtDlp()
+  if (result.status === 'updated') {
+    console.log(`✓ yt-dlp updated${result.from ? `: ${result.from} → ${result.to}` : ` to ${result.to}`}`)
+  } else if (result.status === 'current') {
+    console.log(`✓ yt-dlp is already current (${result.version})`)
+  } else if (result.status === 'system') {
+    console.log(
+      `yoinks uses the yt-dlp already on your PATH${result.version ? ` (${result.version})` : ''} — ` +
+        'update it the way you installed it.',
+    )
+  } else {
+    console.error(`yoinks: could not check for updates — ${result.reason}`)
+    process.exit(1)
+  }
   process.exit(0)
 }
 
@@ -79,6 +102,10 @@ if (isTTY) {
   }
 }
 
+// a stale yt-dlp is the usual reason downloads start failing; keep it fresh
+// quietly while the user works
+const stopAutoUpdate = autoUpdateYtDlp()
+
 let outcome: Outcome = {}
 const {waitUntilExit} = render(
   <App
@@ -92,6 +119,10 @@ const {waitUntilExit} = render(
 )
 
 await waitUntilExit()
+
+// quitting must quit: an in-flight background update would otherwise hold
+// the process open on a restored terminal, looking like a hang
+stopAutoUpdate()
 
 if (isTTY) leaveAltScreen()
 if (outcome.filepath) {

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -28,9 +28,10 @@ const HELP = `
   Options
     --cookies <browser>  sign in using that browser's cookies (firefox,
                          chrome, brave, edge, safari, …). By default yoinks
-                         picks an installed browser itself; --cookies none
-                         stays signed out, --cookies auto restores picking.
-                         Whatever you choose is remembered
+                         picks an installed browser itself — never for
+                         YouTube, which rejects borrowed cookies.
+                         --cookies none stays signed out, --cookies auto
+                         restores picking. Whatever you choose is remembered
     --theme <mode>       use auto, light, or dark for this run
     --update             update the bundled yt-dlp now, then exit
     -h, --help           show this help

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -5,6 +5,7 @@ import {App, type Outcome} from './app.js'
 import {captureFrames} from './lib/click-map.js'
 import {parseArgs} from './lib/args.js'
 import {readClipboard} from './lib/clipboard.js'
+import {loadConfig, saveConfig} from './lib/config.js'
 import {isProbablyUrl} from './lib/platforms.js'
 import {autoUpdateYtDlp, updateYtDlp} from './lib/ytdlp.js'
 
@@ -24,13 +25,17 @@ const HELP = `
     $ yoinks                 (prompts for a url)
 
   Options
-    --theme <mode>  use auto, light, or dark for this run
-    --update        update the bundled yt-dlp now, then exit
-    -h, --help      show this help
-    -v, --version   show version
+    --cookies <browser>  sign in using that browser's cookies, and remember
+                         it (firefox, chrome, brave, edge, safari, …).
+                         --cookies none forgets it again
+    --theme <mode>       use auto, light, or dark for this run
+    --update             update the bundled yt-dlp now, then exit
+    -h, --help           show this help
+    -v, --version        show version
 
   Downloads are saved to ~/Downloads.
   yt-dlp refreshes itself in the background about once a week.
+  Private, age-gated and most Instagram links need --cookies.
   Powered by yt-dlp — YouTube, X, Instagram, Threads, TikTok & 1800+ sites.
 `
 
@@ -74,6 +79,15 @@ if (args.update) {
 const initialUrl = args.initialUrl
 const initialThemeMode = args.themeMode ?? 'auto'
 
+// --cookies is sticky: sites that need a login need it every time, and
+// nobody wants to retype it. `--cookies none` clears the memory.
+const config = loadConfig()
+if (args.cookiesFrom) {
+  const cookiesFrom = args.cookiesFrom === 'none' ? undefined : args.cookiesFrom
+  if (cookiesFrom !== config.cookiesFrom) saveConfig({...config, cookiesFrom})
+  config.cookiesFrom = cookiesFrom
+}
+
 const isTTY = Boolean(process.stdout.isTTY)
 
 // no url given — offer the clipboard url (⇥ to paste) when it already holds one
@@ -112,6 +126,7 @@ const {waitUntilExit} = render(
     initialUrl={initialUrl}
     clipboardUrl={clipboardUrl}
     initialThemeMode={initialThemeMode}
+    cookiesFrom={config.cookiesFrom}
     onOutcome={result => (outcome = result)}
   />,
   // keep a copy of every frame so clicks can be hit-tested against it

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -5,9 +5,10 @@ import {App, type Outcome} from './app.js'
 import {captureFrames} from './lib/click-map.js'
 import {parseArgs} from './lib/args.js'
 import {readClipboard} from './lib/clipboard.js'
+import {detectCookieBrowser} from './lib/browsers.js'
 import {loadConfig, saveConfig} from './lib/config.js'
 import {isProbablyUrl} from './lib/platforms.js'
-import {autoUpdateYtDlp, updateYtDlp} from './lib/ytdlp.js'
+import {autoUpdateYtDlp, sweepStaleInfoFiles, updateYtDlp} from './lib/ytdlp.js'
 
 // read at runtime from the shipped package.json so npm version bumps
 // can't drift from a hardcoded constant
@@ -25,9 +26,11 @@ const HELP = `
     $ yoinks                 (prompts for a url)
 
   Options
-    --cookies <browser>  sign in using that browser's cookies, and remember
-                         it (firefox, chrome, brave, edge, safari, …).
-                         --cookies none forgets it again
+    --cookies <browser>  sign in using that browser's cookies (firefox,
+                         chrome, brave, edge, safari, …). By default yoinks
+                         picks an installed browser itself; --cookies none
+                         stays signed out, --cookies auto restores picking.
+                         Whatever you choose is remembered
     --theme <mode>       use auto, light, or dark for this run
     --update             update the bundled yt-dlp now, then exit
     -h, --help           show this help
@@ -79,14 +82,21 @@ if (args.update) {
 const initialUrl = args.initialUrl
 const initialThemeMode = args.themeMode ?? 'auto'
 
-// --cookies is sticky: sites that need a login need it every time, and
-// nobody wants to retype it. `--cookies none` clears the memory.
+// Cookies are on by default: without them Instagram, private and age-gated
+// links simply fail, and the browser is right there. `--cookies <browser>`
+// pins one, `--cookies none` stays signed out, `--cookies auto` goes back to
+// picking automatically — all three are remembered.
 const config = loadConfig()
 if (args.cookiesFrom) {
-  const cookiesFrom = args.cookiesFrom === 'none' ? undefined : args.cookiesFrom
-  if (cookiesFrom !== config.cookiesFrom) saveConfig({...config, cookiesFrom})
-  config.cookiesFrom = cookiesFrom
+  const stored = args.cookiesFrom === 'none' ? 'off' : args.cookiesFrom === 'auto' ? undefined : args.cookiesFrom
+  saveConfig({...config, cookiesFrom: stored})
+  config.cookiesFrom = stored
 }
+// an auto-picked browser may not hold usable cookies — the app falls back to
+// signed-out rather than failing a download over it
+const cookiesAuto = config.cookiesFrom === undefined
+const cookiesFrom =
+  config.cookiesFrom === 'off' ? undefined : cookiesAuto ? detectCookieBrowser() : config.cookiesFrom
 
 const isTTY = Boolean(process.stdout.isTTY)
 
@@ -119,6 +129,7 @@ if (isTTY) {
 // a stale yt-dlp is the usual reason downloads start failing; keep it fresh
 // quietly while the user works
 const stopAutoUpdate = autoUpdateYtDlp()
+void sweepStaleInfoFiles()
 
 let outcome: Outcome = {}
 const {waitUntilExit} = render(
@@ -126,7 +137,8 @@ const {waitUntilExit} = render(
     initialUrl={initialUrl}
     clipboardUrl={clipboardUrl}
     initialThemeMode={initialThemeMode}
-    cookiesFrom={config.cookiesFrom}
+    cookiesFrom={cookiesFrom}
+    cookiesAuto={cookiesAuto}
     onOutcome={result => (outcome = result)}
   />,
   // keep a copy of every frame so clicks can be hit-tested against it

--- a/src/lib/args.test.ts
+++ b/src/lib/args.test.ts
@@ -23,6 +23,19 @@ test('parses an equals-style theme option after the url', () => {
   })
 })
 
+test('accepts a browser for --cookies in both spellings, and “none” to forget it', () => {
+  assert.equal(parseArgs(['--cookies', 'firefox']).cookiesFrom, 'firefox')
+  assert.equal(parseArgs(['--cookies=Chrome']).cookiesFrom, 'chrome')
+  assert.equal(parseArgs(['--cookies', 'none']).cookiesFrom, 'none')
+  assert.equal(parseArgs(['https://example.com/video']).cookiesFrom, undefined)
+})
+
+test('rejects a browser yt-dlp cannot read cookies from', () => {
+  assert.match(parseArgs(['--cookies']).error ?? '', /needs a browser/)
+  assert.match(parseArgs(['--cookies', 'netscape']).error ?? '', /can’t read cookies/)
+  assert.match(parseArgs(['--cookies=']).error ?? '', /can’t read cookies/)
+})
+
 test('takes --update as a standalone chore, with or without a url', () => {
   assert.equal(parseArgs(['--update']).update, true)
   assert.equal(parseArgs([]).update, false)

--- a/src/lib/args.test.ts
+++ b/src/lib/args.test.ts
@@ -7,6 +7,7 @@ test('parses a url and a spaced theme option without confusing the value for the
   assert.deepEqual(parseArgs(['--theme', 'light', 'https://example.com/video']), {
     help: false,
     version: false,
+    update: false,
     themeMode: 'light',
     initialUrl: 'https://example.com/video',
   })
@@ -16,9 +17,16 @@ test('parses an equals-style theme option after the url', () => {
   assert.deepEqual(parseArgs(['https://example.com/video', '--theme=dark']), {
     help: false,
     version: false,
+    update: false,
     themeMode: 'dark',
     initialUrl: 'https://example.com/video',
   })
+})
+
+test('takes --update as a standalone chore, with or without a url', () => {
+  assert.equal(parseArgs(['--update']).update, true)
+  assert.equal(parseArgs([]).update, false)
+  assert.equal(parseArgs(['https://example.com/video']).update, false)
 })
 
 test('rejects missing, invalid, and unknown options', () => {

--- a/src/lib/args.test.ts
+++ b/src/lib/args.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {parseArgs} from './args.js'
+import {detectCookieBrowser} from './browsers.js'
 import {isThemeMode, nextThemeMode, themeFor} from '../theme.js'
 
 test('parses a url and a spaced theme option without confusing the value for the url', () => {
@@ -23,11 +24,23 @@ test('parses an equals-style theme option after the url', () => {
   })
 })
 
-test('accepts a browser for --cookies in both spellings, and “none” to forget it', () => {
+test('accepts a browser for --cookies in both spellings, plus none and auto', () => {
   assert.equal(parseArgs(['--cookies', 'firefox']).cookiesFrom, 'firefox')
   assert.equal(parseArgs(['--cookies=Chrome']).cookiesFrom, 'chrome')
   assert.equal(parseArgs(['--cookies', 'none']).cookiesFrom, 'none')
+  assert.equal(parseArgs(['--cookies', 'auto']).cookiesFrom, 'auto')
   assert.equal(parseArgs(['https://example.com/video']).cookiesFrom, undefined)
+})
+
+test('picks an installed browser, prefers firefox, and gives up quietly on a bare machine', () => {
+  const dirs = (browser: string) => (dir: string) => dir.toLowerCase().includes(browser)
+  assert.equal(detectCookieBrowser(dirs('firefox')), 'firefox')
+  assert.equal(detectCookieBrowser(dirs('chrome')), 'chrome')
+  assert.equal(detectCookieBrowser(dirs('vivaldi')), 'vivaldi')
+  // firefox wins when several are installed: chromium cookie stores are
+  // encrypted on macOS and Windows
+  assert.equal(detectCookieBrowser(dir => /firefox|chrome/i.test(dir)), 'firefox')
+  assert.equal(detectCookieBrowser(() => false), undefined)
 })
 
 test('rejects a browser yt-dlp cannot read cookies from', () => {

--- a/src/lib/args.test.ts
+++ b/src/lib/args.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {parseArgs} from './args.js'
-import {detectCookieBrowser} from './browsers.js'
+import {cookiesForUrl, detectCookieBrowser} from './browsers.js'
 import {isThemeMode, nextThemeMode, themeFor} from '../theme.js'
 
 test('parses a url and a spaced theme option without confusing the value for the url', () => {
@@ -41,6 +41,16 @@ test('picks an installed browser, prefers firefox, and gives up quietly on a bar
   // encrypted on macOS and Windows
   assert.equal(detectCookieBrowser(dir => /firefox|chrome/i.test(dir)), 'firefox')
   assert.equal(detectCookieBrowser(() => false), undefined)
+})
+
+test('keeps guessed cookies away from youtube but honours a pinned browser', () => {
+  const yt = 'https://youtu.be/Ywq6FMLbWH4'
+  const ig = 'https://www.instagram.com/reel/abc123/'
+  assert.equal(cookiesForUrl('firefox', true, yt), undefined)
+  assert.equal(cookiesForUrl('firefox', true, 'https://music.youtube.com/watch?v=abc'), undefined)
+  assert.equal(cookiesForUrl('firefox', true, ig), 'firefox')
+  assert.equal(cookiesForUrl('firefox', false, yt), 'firefox')
+  assert.equal(cookiesForUrl(undefined, true, ig), undefined)
 })
 
 test('rejects a browser yt-dlp cannot read cookies from', () => {

--- a/src/lib/args.ts
+++ b/src/lib/args.ts
@@ -7,17 +7,21 @@ export type CliArgs = {
   update: boolean
   initialUrl?: string
   themeMode?: ThemeMode
-  /** A browser name, or 'none' to forget the remembered one. */
-  cookiesFrom?: CookieBrowser | 'none'
+  /**
+   * A browser name pins it, 'none' stays signed out, 'auto' goes back to
+   * picking an installed browser by itself.
+   */
+  cookiesFrom?: CookieBrowser | 'none' | 'auto'
   error?: string
 }
 
-const COOKIE_VALUES = `${COOKIE_BROWSERS.join(', ')}, or none`
+const COOKIE_VALUES = `${COOKIE_BROWSERS.join(', ')}, auto, or none`
 
-function readCookiesValue(value: string | undefined): CookieBrowser | 'none' | undefined {
+function readCookiesValue(value: string | undefined): CookieBrowser | 'none' | 'auto' | undefined {
   if (!value) return undefined
   const normalized = value.toLowerCase()
   if (normalized === 'none' || normalized === 'off') return 'none'
+  if (normalized === 'auto') return 'auto'
   return isCookieBrowser(normalized) ? normalized : undefined
 }
 

--- a/src/lib/args.ts
+++ b/src/lib/args.ts
@@ -3,13 +3,14 @@ import {isThemeMode, type ThemeMode} from '../theme.js'
 export type CliArgs = {
   help: boolean
   version: boolean
+  update: boolean
   initialUrl?: string
   themeMode?: ThemeMode
   error?: string
 }
 
 export function parseArgs(args: string[]): CliArgs {
-  const result: CliArgs = {help: false, version: false}
+  const result: CliArgs = {help: false, version: false, update: false}
   const positional: string[] = []
 
   for (let index = 0; index < args.length; index++) {
@@ -18,6 +19,8 @@ export function parseArgs(args: string[]): CliArgs {
       result.help = true
     } else if (arg === '-v' || arg === '--version') {
       result.version = true
+    } else if (arg === '--update') {
+      result.update = true
     } else if (arg === '--theme') {
       const value = args[++index]
       if (!value) return {...result, error: '--theme needs a value: auto, light, or dark'}

--- a/src/lib/args.ts
+++ b/src/lib/args.ts
@@ -1,4 +1,5 @@
 import {isThemeMode, type ThemeMode} from '../theme.js'
+import {COOKIE_BROWSERS, isCookieBrowser, type CookieBrowser} from './config.js'
 
 export type CliArgs = {
   help: boolean
@@ -6,7 +7,18 @@ export type CliArgs = {
   update: boolean
   initialUrl?: string
   themeMode?: ThemeMode
+  /** A browser name, or 'none' to forget the remembered one. */
+  cookiesFrom?: CookieBrowser | 'none'
   error?: string
+}
+
+const COOKIE_VALUES = `${COOKIE_BROWSERS.join(', ')}, or none`
+
+function readCookiesValue(value: string | undefined): CookieBrowser | 'none' | undefined {
+  if (!value) return undefined
+  const normalized = value.toLowerCase()
+  if (normalized === 'none' || normalized === 'off') return 'none'
+  return isCookieBrowser(normalized) ? normalized : undefined
 }
 
 export function parseArgs(args: string[]): CliArgs {
@@ -21,6 +33,17 @@ export function parseArgs(args: string[]): CliArgs {
       result.version = true
     } else if (arg === '--update') {
       result.update = true
+    } else if (arg === '--cookies') {
+      const value = args[++index]
+      if (!value) return {...result, error: `--cookies needs a browser: ${COOKIE_VALUES}`}
+      const parsed = readCookiesValue(value)
+      if (!parsed) return {...result, error: `can’t read cookies from “${value}” — use ${COOKIE_VALUES}`}
+      result.cookiesFrom = parsed
+    } else if (arg.startsWith('--cookies=')) {
+      const value = arg.slice('--cookies='.length)
+      const parsed = readCookiesValue(value)
+      if (!parsed) return {...result, error: `can’t read cookies from “${value}” — use ${COOKIE_VALUES}`}
+      result.cookiesFrom = parsed
     } else if (arg === '--theme') {
       const value = args[++index]
       if (!value) return {...result, error: '--theme needs a value: auto, light, or dark'}

--- a/src/lib/browsers.ts
+++ b/src/lib/browsers.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import type {CookieBrowser} from './config.js'
+import {detectPlatform} from './platforms.js'
 
 /**
  * Where each browser keeps its profile, per platform. Presence of the folder
@@ -61,6 +62,26 @@ function profileCandidates(): Array<[CookieBrowser, string[]]> {
     ['vivaldi', [path.join(config, 'vivaldi')]],
     ['opera', [path.join(config, 'opera')]],
   ]
+}
+
+/**
+ * The cookies we actually hand yt-dlp for one link.
+ *
+ * YouTube is the exception. It rotates the cookies of a signed-in session
+ * constantly, so the jar of a running browser is usually stale by the time
+ * yt-dlp reads it, and the player answers “The page needs to be reloaded”
+ * for a video that downloads fine signed out. yt-dlp warns against feeding
+ * it YouTube account cookies for that reason too. So a browser *we* guessed
+ * stays out of YouTube's way, while a browser pinned with --cookies is still
+ * used — that one is a deliberate choice for links that need an account.
+ */
+export function cookiesForUrl(
+  cookiesFrom: string | undefined,
+  guessed: boolean | undefined,
+  url: string,
+): string | undefined {
+  if (!cookiesFrom) return undefined
+  return guessed && detectPlatform(url).key === 'youtube' ? undefined : cookiesFrom
 }
 
 /** First installed browser we can borrow cookies from, if any. */

--- a/src/lib/browsers.ts
+++ b/src/lib/browsers.ts
@@ -1,0 +1,72 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type {CookieBrowser} from './config.js'
+
+/**
+ * Where each browser keeps its profile, per platform. Presence of the folder
+ * is enough — yt-dlp does the real cookie reading, and asking it to try a
+ * browser that isn't installed just wastes a spawn.
+ *
+ * Order matters: it is the order we try them in. Firefox leads because
+ * Chromium browsers encrypt their cookie store on macOS and Windows, where
+ * reading it often fails. Safari is deliberately absent — touching its
+ * cookies raises a system permission prompt nobody asked for.
+ */
+function profileCandidates(): Array<[CookieBrowser, string[]]> {
+  const home = os.homedir()
+  const appData = process.env.APPDATA ?? path.join(home, 'AppData', 'Roaming')
+  const localAppData = process.env.LOCALAPPDATA ?? path.join(home, 'AppData', 'Local')
+
+  if (process.platform === 'win32') {
+    return [
+      ['firefox', [path.join(appData, 'Mozilla', 'Firefox')]],
+      ['brave', [path.join(localAppData, 'BraveSoftware', 'Brave-Browser')]],
+      ['chrome', [path.join(localAppData, 'Google', 'Chrome')]],
+      ['chromium', [path.join(localAppData, 'Chromium')]],
+      ['edge', [path.join(localAppData, 'Microsoft', 'Edge')]],
+      ['vivaldi', [path.join(localAppData, 'Vivaldi')]],
+      ['opera', [path.join(appData, 'Opera Software', 'Opera Stable')]],
+    ]
+  }
+
+  if (process.platform === 'darwin') {
+    const support = path.join(home, 'Library', 'Application Support')
+    return [
+      ['firefox', [path.join(support, 'Firefox')]],
+      ['brave', [path.join(support, 'BraveSoftware', 'Brave-Browser')]],
+      ['chrome', [path.join(support, 'Google', 'Chrome')]],
+      ['chromium', [path.join(support, 'Chromium')]],
+      ['edge', [path.join(support, 'Microsoft Edge')]],
+      ['vivaldi', [path.join(support, 'Vivaldi')]],
+      ['opera', [path.join(support, 'com.operasoftware.Opera')]],
+    ]
+  }
+
+  const config = path.join(home, '.config')
+  return [
+    // snap and flatpak keep their own copies of the profile
+    [
+      'firefox',
+      [
+        path.join(home, '.mozilla', 'firefox'),
+        path.join(home, 'snap', 'firefox', 'common', '.mozilla', 'firefox'),
+        path.join(home, '.var', 'app', 'org.mozilla.firefox', '.mozilla', 'firefox'),
+      ],
+    ],
+    ['brave', [path.join(config, 'BraveSoftware', 'Brave-Browser')]],
+    ['chrome', [path.join(config, 'google-chrome')]],
+    ['chromium', [path.join(config, 'chromium'), path.join(home, 'snap', 'chromium', 'common', 'chromium')]],
+    ['edge', [path.join(config, 'microsoft-edge')]],
+    ['vivaldi', [path.join(config, 'vivaldi')]],
+    ['opera', [path.join(config, 'opera')]],
+  ]
+}
+
+/** First installed browser we can borrow cookies from, if any. */
+export function detectCookieBrowser(exists: (dir: string) => boolean = fs.existsSync): CookieBrowser | undefined {
+  for (const [browser, dirs] of profileCandidates()) {
+    if (dirs.some(dir => exists(dir))) return browser
+  }
+  return undefined
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const CONFIG_FILE = path.join(os.homedir(), '.config', 'yoinks', 'config.json')
+
+/** Browsers yt-dlp can read cookies from. */
+export const COOKIE_BROWSERS = [
+  'brave',
+  'chrome',
+  'chromium',
+  'edge',
+  'firefox',
+  'opera',
+  'safari',
+  'vivaldi',
+  'whale',
+] as const
+
+export type CookieBrowser = (typeof COOKIE_BROWSERS)[number]
+
+export function isCookieBrowser(value: string): value is CookieBrowser {
+  return (COOKIE_BROWSERS as readonly string[]).includes(value)
+}
+
+export type Config = {
+  /** Browser to borrow cookies from; unset means anonymous downloads. */
+  cookiesFrom?: CookieBrowser
+}
+
+export function loadConfig(): Config {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'))
+    if (!parsed || typeof parsed !== 'object') return {}
+    const {cookiesFrom} = parsed as {cookiesFrom?: unknown}
+    return typeof cookiesFrom === 'string' && isCookieBrowser(cookiesFrom) ? {cookiesFrom} : {}
+  } catch {
+    return {}
+  }
+}
+
+/** Persist settings so `--cookies` only has to be typed once. */
+export function saveConfig(config: Config): void {
+  try {
+    fs.mkdirSync(path.dirname(CONFIG_FILE), {recursive: true})
+    fs.writeFileSync(CONFIG_FILE, `${JSON.stringify(config, null, 2)}\n`)
+  } catch {
+    // a read-only home shouldn't stop anyone from downloading a video
+  }
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -24,8 +24,11 @@ export function isCookieBrowser(value: string): value is CookieBrowser {
 }
 
 export type Config = {
-  /** Browser to borrow cookies from; unset means anonymous downloads. */
-  cookiesFrom?: CookieBrowser
+  /**
+   * Browser to borrow cookies from. A browser name pins that one, 'off' means
+   * stay signed out, and unset means "figure it out" — see detectCookieBrowser.
+   */
+  cookiesFrom?: CookieBrowser | 'off'
 }
 
 export function loadConfig(): Config {
@@ -33,6 +36,7 @@ export function loadConfig(): Config {
     const parsed: unknown = JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'))
     if (!parsed || typeof parsed !== 'object') return {}
     const {cookiesFrom} = parsed as {cookiesFrom?: unknown}
+    if (cookiesFrom === 'off') return {cookiesFrom: 'off'}
     return typeof cookiesFrom === 'string' && isCookieBrowser(cookiesFrom) ? {cookiesFrom} : {}
   } catch {
     return {}

--- a/src/lib/reveal.ts
+++ b/src/lib/reveal.ts
@@ -2,17 +2,21 @@ import {spawn} from 'node:child_process'
 import path from 'node:path'
 
 /**
- * Show a finished download in the system file manager. macOS and Windows can
- * highlight the file itself; elsewhere the best we can do is open the folder.
+ * Show a finished download in the system file manager. macOS can highlight
+ * the file itself; elsewhere the best we can do is open the folder.
  * Resolves false when there is nothing to open with, so the UI can say so
  * instead of looking like the keypress did nothing.
  */
 export function revealInFileManager(filepath: string): Promise<boolean> {
+  // explorer's /select flag is meant to open the folder with the file
+  // highlighted, but it silently falls back to the Documents folder unless
+  // an explorer.exe window has already been opened this session — plain
+  // folder is what actually works every time
   const [command, args]: [string, string[]] =
     process.platform === 'darwin'
       ? ['open', ['-R', filepath]]
       : process.platform === 'win32'
-        ? ['explorer', [`/select,${filepath}`]]
+        ? ['explorer', [path.dirname(filepath)]]
         : ['xdg-open', [path.dirname(filepath)]]
 
   return new Promise(resolve => {

--- a/src/lib/reveal.ts
+++ b/src/lib/reveal.ts
@@ -1,0 +1,34 @@
+import {spawn} from 'node:child_process'
+import path from 'node:path'
+
+/**
+ * Show a finished download in the system file manager. macOS and Windows can
+ * highlight the file itself; elsewhere the best we can do is open the folder.
+ * Resolves false when there is nothing to open with, so the UI can say so
+ * instead of looking like the keypress did nothing.
+ */
+export function revealInFileManager(filepath: string): Promise<boolean> {
+  const [command, args]: [string, string[]] =
+    process.platform === 'darwin'
+      ? ['open', ['-R', filepath]]
+      : process.platform === 'win32'
+        ? ['explorer', [`/select,${filepath}`]]
+        : ['xdg-open', [path.dirname(filepath)]]
+
+  return new Promise(resolve => {
+    let child
+    try {
+      // detached: the file manager outlives yoinks, and its output must not
+      // land in the alternate screen we're drawing on
+      child = spawn(command, args, {stdio: 'ignore', detached: true, timeout: 5_000})
+    } catch {
+      resolve(false)
+      return
+    }
+    child.on('error', () => resolve(false))
+    // explorer.exe exits non-zero even when it worked, so on Windows only a
+    // spawn failure counts as failure
+    child.on('close', code => resolve(process.platform === 'win32' || code === 0))
+    child.unref()
+  })
+}

--- a/src/lib/ytdlp.ts
+++ b/src/lib/ytdlp.ts
@@ -9,6 +9,9 @@ import {formatBytes} from './format.js'
 
 const YOINKS_DIR = path.join(os.homedir(), '.yoinks', 'bin')
 const RELEASE_BASE = 'https://github.com/yt-dlp/yt-dlp/releases/latest/download'
+const LATEST_RELEASE_API = 'https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest'
+const UPDATE_STAMP = path.join(YOINKS_DIR, 'update-check.json')
+const UPDATE_CHECK_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000
 
 function ytDlpAssetName(): string {
   if (process.platform === 'win32') return 'yt-dlp.exe'
@@ -32,6 +35,50 @@ function commandWorks(cmd: string, args: string[]): Promise<boolean> {
   })
 }
 
+// same as commandWorks, but keeps stdout — used to read `--version`
+function commandOutput(cmd: string, args: string[]): Promise<string | undefined> {
+  return new Promise(resolve => {
+    let child
+    try {
+      child = spawn(cmd, args, {stdio: ['ignore', 'pipe', 'ignore'], timeout: 10_000})
+    } catch {
+      resolve(undefined)
+      return
+    }
+    let out = ''
+    child.stdout.on('data', chunk => (out += chunk))
+    child.on('error', () => resolve(undefined))
+    child.on('close', code => resolve(code === 0 ? out.trim() || undefined : undefined))
+  })
+}
+
+/** Where yoinks keeps its own copy of yt-dlp — the only one it ever replaces. */
+export function managedYtDlpPath(): string {
+  return path.join(YOINKS_DIR, process.platform === 'win32' ? 'yt-dlp.exe' : 'yt-dlp')
+}
+
+/** Fetch the standalone binary and swap it in atomically. */
+async function fetchYtDlp(dest: string, signal?: AbortSignal): Promise<void> {
+  await fs.mkdir(path.dirname(dest), {recursive: true})
+
+  const response = await fetch(`${RELEASE_BASE}/${ytDlpAssetName()}`, {signal})
+  if (!response.ok || !response.body) {
+    throw new Error(`Could not download yt-dlp (${response.status}). Check your connection and try again.`)
+  }
+
+  // write beside the target, then rename: a half-written binary is never
+  // visible under the real name, and a copy already running keeps its inode
+  const tmp = `${dest}.${process.pid}.download`
+  try {
+    await pipeline(Readable.fromWeb(response.body as never), createWriteStream(tmp), {signal})
+    await fs.chmod(tmp, 0o755)
+    await fs.rename(tmp, dest)
+  } catch (error) {
+    await fs.rm(tmp, {force: true})
+    throw error
+  }
+}
+
 /**
  * Resolve a usable yt-dlp binary: system install first, then a previously
  * downloaded copy, then download the standalone binary from GitHub releases.
@@ -39,23 +86,99 @@ function commandWorks(cmd: string, args: string[]): Promise<boolean> {
 export async function ensureYtDlp(onStatus: (message: string) => void, signal?: AbortSignal): Promise<string> {
   if (await commandWorks('yt-dlp', ['--version'])) return 'yt-dlp'
 
-  const local = path.join(YOINKS_DIR, process.platform === 'win32' ? 'yt-dlp.exe' : 'yt-dlp')
+  const local = managedYtDlpPath()
   if (await commandWorks(local, ['--version'])) return local
 
   onStatus('first run: fetching yt-dlp…')
-  await fs.mkdir(YOINKS_DIR, {recursive: true})
+  await fetchYtDlp(local, signal)
+  return local
+}
 
-  const url = `${RELEASE_BASE}/${ytDlpAssetName()}`
-  const response = await fetch(url, {signal})
-  if (!response.ok || !response.body) {
-    throw new Error(`Could not download yt-dlp (${response.status}). Check your connection and try again.`)
+export type UpdateResult =
+  | {status: 'updated'; from?: string; to: string}
+  | {status: 'current'; version: string}
+  | {status: 'system'; version?: string}
+  | {status: 'unavailable'; reason: string}
+
+async function latestYtDlpVersion(signal?: AbortSignal): Promise<string | undefined> {
+  const response = await fetch(LATEST_RELEASE_API, {
+    signal,
+    headers: {accept: 'application/vnd.github+json', 'user-agent': 'yoinks'},
+  })
+  if (!response.ok) return undefined
+  const release = (await response.json()) as {tag_name?: unknown}
+  return typeof release.tag_name === 'string' ? release.tag_name.trim() || undefined : undefined
+}
+
+async function markUpdateChecked(version?: string): Promise<void> {
+  try {
+    await fs.mkdir(YOINKS_DIR, {recursive: true})
+    await fs.writeFile(UPDATE_STAMP, `${JSON.stringify({checkedAt: Date.now(), version: version ?? null})}\n`)
+  } catch {
+    // the stamp is an optimisation — worst case we check again next run
+  }
+}
+
+async function updateCheckDue(): Promise<boolean> {
+  try {
+    const stamp = JSON.parse(await fs.readFile(UPDATE_STAMP, 'utf8')) as {checkedAt?: unknown}
+    if (typeof stamp.checkedAt !== 'number') return true
+    return Date.now() - stamp.checkedAt > UPDATE_CHECK_INTERVAL_MS
+  } catch {
+    return true
+  }
+}
+
+/**
+ * Refresh the copy of yt-dlp in ~/.yoinks/bin. A yt-dlp that came from the
+ * user's package manager is reported, never overwritten — that install isn't
+ * ours to touch.
+ */
+export async function updateYtDlp(signal?: AbortSignal): Promise<UpdateResult> {
+  if (await commandWorks('yt-dlp', ['--version'])) {
+    return {status: 'system', version: await commandOutput('yt-dlp', ['--version'])}
   }
 
-  const tmp = `${local}.download`
-  await pipeline(Readable.fromWeb(response.body as never), createWriteStream(tmp), {signal})
-  await fs.chmod(tmp, 0o755)
-  await fs.rename(tmp, local)
-  return local
+  const local = managedYtDlpPath()
+  const current = await commandOutput(local, ['--version'])
+
+  let latest: string | undefined
+  try {
+    latest = await latestYtDlpVersion(signal)
+  } catch (error) {
+    return {status: 'unavailable', reason: error instanceof Error ? error.message : String(error)}
+  }
+  if (!latest) return {status: 'unavailable', reason: 'could not reach the yt-dlp release feed'}
+
+  if (current && current === latest) {
+    await markUpdateChecked(latest)
+    return {status: 'current', version: current}
+  }
+
+  await fetchYtDlp(local, signal)
+  await markUpdateChecked(latest)
+  return {status: 'updated', from: current, to: latest}
+}
+
+/**
+ * Weekly background refresh, silent by design. A months-old yt-dlp is the
+ * usual reason downloads suddenly start failing, and the user can't act on a
+ * mid-session notice anyway. Returns a canceller — the caller aborts it on
+ * exit so a slow download can't keep the terminal hostage after quitting.
+ */
+export function autoUpdateYtDlp(): () => void {
+  const controller = new AbortController()
+  void (async () => {
+    try {
+      if (!(await updateCheckDue())) return
+      // never on first run: ensureYtDlp is about to fetch a fresh binary anyway
+      if (!(await commandWorks(managedYtDlpPath(), ['--version']))) return
+      await updateYtDlp(controller.signal)
+    } catch {
+      // offline, rate-limited, no disk space — yoinks runs on what it has
+    }
+  })()
+  return () => controller.abort()
 }
 
 /**
@@ -209,6 +332,11 @@ export type DownloadHandlers = {
   onProcessing: () => void
 }
 
+// YouTube and most HLS sites hand out fragmented media; pulling four
+// fragments at once is the single biggest speed win available here, and it
+// is a no-op for sites that serve one plain file
+const CONCURRENT_FRAGMENTS = '4'
+
 const PROGRESS_PREFIX = 'YOINK|'
 const PROGRESS_TEMPLATE = `${PROGRESS_PREFIX}%(progress.downloaded_bytes)s|%(progress.total_bytes)s|%(progress.total_bytes_estimate)s|%(progress.speed)s|%(progress.eta)s`
 
@@ -231,6 +359,8 @@ export function download(
   const args = [
     ...(opts.infoJsonPath ? ['--load-info-json', opts.infoJsonPath] : [opts.url]),
     ...opts.choice.args,
+    '--concurrent-fragments',
+    CONCURRENT_FRAGMENTS,
     '--no-playlist',
     '--no-warnings',
     '--newline',

--- a/src/lib/ytdlp.ts
+++ b/src/lib/ytdlp.ts
@@ -226,9 +226,24 @@ export type ProbeResult = {
   infoJsonPath: string
 }
 
-export async function probe(ytdlp: string, url: string, signal?: AbortSignal): Promise<ProbeResult> {
+/**
+ * Borrow the browser's cookies so private, age-gated and login-walled pages
+ * (Instagram in particular) work at all. Empty when no browser is configured.
+ */
+function cookieArgs(cookiesFrom?: string): string[] {
+  return cookiesFrom ? ['--cookies-from-browser', cookiesFrom] : []
+}
+
+export async function probe(
+  ytdlp: string,
+  url: string,
+  opts: {cookiesFrom?: string} = {},
+  signal?: AbortSignal,
+): Promise<ProbeResult> {
   const stdout = await new Promise<string>((resolve, reject) => {
-    const child = spawn(ytdlp, ['-J', '--no-playlist', '--no-warnings', url], {signal})
+    const child = spawn(ytdlp, ['-J', '--no-playlist', '--no-warnings', ...cookieArgs(opts.cookiesFrom), url], {
+      signal,
+    })
     let out = ''
     let stderr = ''
     child.stdout.on('data', chunk => (out += chunk))
@@ -350,6 +365,7 @@ export function download(
     url: string
     /** When set, reuse the probe's metadata instead of re-extracting — starts much faster. */
     infoJsonPath?: string
+    cookiesFrom?: string
     choice: DownloadChoice
     outDir: string
   },
@@ -359,6 +375,7 @@ export function download(
   const args = [
     ...(opts.infoJsonPath ? ['--load-info-json', opts.infoJsonPath] : [opts.url]),
     ...opts.choice.args,
+    ...cookieArgs(opts.cookiesFrom),
     '--concurrent-fragments',
     CONCURRENT_FRAGMENTS,
     '--no-playlist',

--- a/src/lib/ytdlp.ts
+++ b/src/lib/ytdlp.ts
@@ -1,5 +1,5 @@
 import {spawn, type ChildProcess} from 'node:child_process'
-import {createWriteStream} from 'node:fs'
+import {createWriteStream, rmSync} from 'node:fs'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
@@ -265,9 +265,49 @@ export async function probe(
     throw new Error('Could not parse video info from yt-dlp.')
   }
 
-  const infoJsonPath = path.join(os.tmpdir(), `yoinks-info-${process.pid}-${Date.now()}.json`)
+  const infoJsonPath = path.join(os.tmpdir(), `${INFO_PREFIX}${process.pid}-${Date.now()}.json`)
   await fs.writeFile(infoJsonPath, stdout)
+  infoJsonFiles.add(infoJsonPath)
   return {info, infoJsonPath}
+}
+
+const INFO_PREFIX = 'yoinks-info-'
+
+// metadata dumps are only useful for the run that made them; keep track and
+// take them with us on the way out instead of silting up /tmp
+const infoJsonFiles = new Set<string>()
+process.on('exit', () => {
+  for (const file of infoJsonFiles) {
+    try {
+      rmSync(file, {force: true})
+    } catch {
+      // nothing sensible to do while exiting
+    }
+  }
+})
+
+/** Clear out dumps left by runs that were killed before they could tidy up. */
+export async function sweepStaleInfoFiles(maxAgeMs = 24 * 60 * 60 * 1000): Promise<void> {
+  try {
+    const dir = os.tmpdir()
+    const names = await fs.readdir(dir)
+    const cutoff = Date.now() - maxAgeMs
+    await Promise.all(
+      names
+        .filter(name => name.startsWith(INFO_PREFIX) && name.endsWith('.json'))
+        .map(async name => {
+          const file = path.join(dir, name)
+          try {
+            const stat = await fs.stat(file)
+            if (stat.mtimeMs < cutoff) await fs.rm(file, {force: true})
+          } catch {
+            // someone else's file, or already gone
+          }
+        }),
+    )
+  } catch {
+    // no readable temp dir — not worth a word to the user
+  }
 }
 
 export type DownloadChoice = {


### PR DESCRIPTION
Made some changes with claude
- added flag `--concurrent-fragments 4` - now it should download faster
- added flag `--cookies-from-browser firefox`, now it attaches it, so for example instagram downloads some videos correctly
- after download you can press `o` and the folder should open where you downloaded video
- current version has all logs be put into /tmp folder without any scripts clearing it, should be fixed now